### PR TITLE
Delete constants directory

### DIFF
--- a/constants/colors.py
+++ b/constants/colors.py
@@ -1,4 +1,0 @@
-from colorama import Fore
-
-GREEN = Fore.GREEN
-RED = Fore.RED


### PR DESCRIPTION
This directory is no longer needed since we no longer use colorama, which was used for text coloring in the terminal.